### PR TITLE
feat: configura nosso projeto em relação ao consumo da api do covid.

### DIFF
--- a/plataforma-benchmark-covid-backend/src/main/java/com/yuritech/plataforma_benchmark_covid_backend/infra/client/CovidApiClient.java
+++ b/plataforma-benchmark-covid-backend/src/main/java/com/yuritech/plataforma_benchmark_covid_backend/infra/client/CovidApiClient.java
@@ -1,0 +1,15 @@
+package com.yuritech.plataforma_benchmark_covid_backend.infra.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name = "covidApi", url = "https://api.api-ninjas.com/v1")
+public interface CovidApiClient {
+    @GetMapping("/covid19")
+    CovidApiClientResponseDTO[] buscarDados(
+            @RequestParam("country") String country,
+            @RequestParam("type") String type,
+            @RequestHeader("X-Api-Key") String apiKey);
+}

--- a/plataforma-benchmark-covid-backend/src/main/java/com/yuritech/plataforma_benchmark_covid_backend/infra/client/CovidApiClientResponseDTO.java
+++ b/plataforma-benchmark-covid-backend/src/main/java/com/yuritech/plataforma_benchmark_covid_backend/infra/client/CovidApiClientResponseDTO.java
@@ -1,0 +1,18 @@
+package com.yuritech.plataforma_benchmark_covid_backend.infra.client;
+
+
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.Map;
+
+@Data
+@AllArgsConstructor
+public class CovidApiClientResponseDTO {
+    private String country;
+    private Map<String, CovidDetailsDTO> cases;
+    private Map<String, CovidDetailsDTO> deaths;
+
+}

--- a/plataforma-benchmark-covid-backend/src/main/java/com/yuritech/plataforma_benchmark_covid_backend/infra/client/CovidApiClientService.java
+++ b/plataforma-benchmark-covid-backend/src/main/java/com/yuritech/plataforma_benchmark_covid_backend/infra/client/CovidApiClientService.java
@@ -1,0 +1,33 @@
+package com.yuritech.plataforma_benchmark_covid_backend.infra.client;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class CovidApiClientService {
+
+    private final CovidApiClient covidApiClient;
+
+    public CovidApiClientResponseDTO buscarDadosCovid(String countryName){
+
+        String apiKeyValue = "2BWFsIzdHWMRDmp8aST5+A==bhCpRRQP52PpzHVY";
+        CovidApiClientResponseDTO[] casos = covidApiClient.buscarDados(countryName, "cases", apiKeyValue);
+        CovidApiClientResponseDTO[] mortes = covidApiClient.buscarDados(countryName, "deaths", apiKeyValue);
+
+        System.out.println(casos);
+
+        if (casos.length == 1 && mortes.length == 1) {
+            String country = casos[0].getCountry();
+            Map<String, CovidDetailsDTO> cases = casos[0].getCases();
+            Map<String, CovidDetailsDTO> deaths = mortes[0].getDeaths();
+
+            return new CovidApiClientResponseDTO(country, cases, deaths);
+        }
+
+        return null;
+    }
+
+}

--- a/plataforma-benchmark-covid-backend/src/main/java/com/yuritech/plataforma_benchmark_covid_backend/infra/client/CovidDetailsDTO.java
+++ b/plataforma-benchmark-covid-backend/src/main/java/com/yuritech/plataforma_benchmark_covid_backend/infra/client/CovidDetailsDTO.java
@@ -1,0 +1,11 @@
+package com.yuritech.plataforma_benchmark_covid_backend.infra.client;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class CovidDetailsDTO {
+    private int total;
+    private int novosDados;
+}


### PR DESCRIPTION
feat: configura o open feign para realizar o consumo da api e implementa lógica de abstração dos dados da api em questão a partir do service e dos seus métodos.